### PR TITLE
CVS support

### DIFF
--- a/bin/vcprompt
+++ b/bin/vcprompt
@@ -309,14 +309,34 @@ def bzr(options):
     }
 
 
-@vcs(['CVSROOT/config'])
+@vcs(['CVS/Root'])
 def cvs(options):
     """
     CVS
 
     Concurrent Versions System.
     """
-    return {}
+    # status (modified/untracked)
+    if re.search('%[mu]', options.format):
+        output, returncode = popen('cvs -Q status -R')
+
+        modified = ''
+        untracked = ''
+
+        if returncode == 0:
+            if output:
+                for line in output.splitlines():
+                    line = line.strip()
+                    if line.startswith('?'):
+                        untracked = options.untracked
+                    elif line.count('Locally Modified'):
+                        modified = options.modified
+
+    # formatting
+    return {
+        'modified': modified,
+        'untracked': untracked,
+    }
 
 
 @vcs(['_darcs/hashed_inventory'])


### PR DESCRIPTION
Please add a basic real support for CVS repositories.

Please note, that CVSROOT/config is not obligatory to checkout. So, one can use a CVS repository without such path available. That's why CVS/Root is used instead.
